### PR TITLE
Remove ParallelSync meta file.

### DIFF
--- a/3D Chess/Assets/ParrelSync.meta
+++ b/3D Chess/Assets/ParrelSync.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 2739caeae15c82940a97a934ae6f724d
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
When removing the ParallelSync folder in https://github.com/realm/unity-examples-3d-chess/pull/1 to re-add it later via NPM I only deleted the ParallalSync folder as advised by their wiki. When cloning the `example-template` branch the meta file for it still exists though which ends in the folder being created again and, more importantly, in a warning in Unity that I'd like to avoid to make sure users are not confused when checking out this example.