### PR TITLE
Remove unused public field type from Piece.

### DIFF
--- a/3D Chess/Assets/Scripts/Piece.cs
+++ b/3D Chess/Assets/Scripts/Piece.cs
@@ -2,8 +2,6 @@ using UnityEngine;
 
 public class Piece : MonoBehaviour
 {
-    public PieceType type = default;
-
     private Events events = default;
     private readonly Color selectedColor = new Color(1, 0, 0, 1);
     private readonly Color deselectedColor = new Color(1, 1, 1, 1);


### PR DESCRIPTION
While re-reading the local Realm tutorial I noticed we don't actually use this public field and can remove it.