### PR TITLE
Add an alternative implementation for the RealmObject handling.

### DIFF
--- a/3D Chess/Assets/Scripts/GameState.cs
+++ b/3D Chess/Assets/Scripts/GameState.cs
@@ -1,3 +1,5 @@
+using Realms;
+using System;
 using System.Linq;
 using UnityEngine;
 
@@ -6,32 +8,83 @@ public class GameState : MonoBehaviour
     [SerializeField] private PieceSpawner pieceSpawner = default;
     [SerializeField] private GameObject pieces = default;
 
-    public void MovePiece(Piece movedPiece, Vector3 newPosition)
-    {
-        // Check if there is already a piece at the new position and if so, remove it.
-        var attackedPiece = FindPiece(newPosition);
-        if (attackedPiece != null)
-        {
-            attackedPiece.RemoveFromBoard();
-        }
+    private Realm realm;
+    private IQueryable<PieceEntity> pieceEntities;
+    private IDisposable notificationToken;
 
-        // Now move the piece to it's new position.
-        movedPiece.transform.position = newPosition;
+    public void MovePiece(Vector3 oldPosition, Vector3 newPosition)
+    {
+        realm.Write(() =>
+        {
+            // Check if there is already a piece at the new position and if so, remove it.
+            var attackedPiece = FindPieceEntity(newPosition);
+
+            // Now move the piece to it's new position.
+            var movedPieceEntity = FindPieceEntity(oldPosition);
+            if (attackedPiece != null)
+            {
+                realm.Remove(attackedPiece);
+            }
+            movedPieceEntity.Position = newPosition;
+        });
     }
 
     public void ResetGame()
     {
-        pieceSpawner.CreateNewBoard(pieces);
+        pieceSpawner.CreateNewBoard(realm);
     }
 
     private void Awake()
     {
-        pieceSpawner.LoadBoard(pieces);
+        realm = Realm.GetInstance();
+        pieceEntities = realm.All<PieceEntity>();
+        notificationToken = pieceEntities.SubscribeForNotifications((sender, changes, error) =>
+        {
+            if (error != null)
+            {
+                Debug.Log(error.ToString());
+                return;
+            }
+
+            // Initial notification
+            // Happens when subscribing, which causes the query to actually being executed (but on a background thread).
+            if (changes == null)
+            {
+                // Check if we actually have PieceEntity's (which means we resume a game).
+                if (sender.Count > 0)
+                {
+                    // Each RealmObject needs a corresponding GameObject to represent it.
+                    foreach (PieceEntity pieceEntity in sender)
+                    {
+                        pieceSpawner.SpawnPiece(pieceEntity, pieces);
+                    }
+                }
+                else
+                {
+                    // No game was saved, create a new board.
+                    pieceSpawner.CreateNewBoard(realm);
+                }
+                return;
+            }
+
+            foreach (var index in changes.InsertedIndices)
+            {
+                var pieceEntity = sender[index];
+                pieceSpawner.SpawnPiece(pieceEntity, pieces);
+            }
+        });
     }
 
-    private Piece FindPiece(Vector3 position)
+    private void OnDestroy()
     {
-        return pieces.GetComponentsInChildren<Piece>()
-            .FirstOrDefault(piece => piece.transform.position == position);
+        notificationToken.Dispose();
+    }
+
+    private PieceEntity FindPieceEntity(Vector3 position)
+    {
+        return pieceEntities
+                 .Filter("PositionEntity.X == $0 && PositionEntity.Y == $1 && PositionEntity.Z == $2",
+                         position.x, position.y, position.z)
+                 .FirstOrDefault();
     }
 }

--- a/3D Chess/Assets/Scripts/InputListener.cs
+++ b/3D Chess/Assets/Scripts/InputListener.cs
@@ -33,7 +33,7 @@ public class InputListener : MonoBehaviour
     {
         if (activePiece != null)
         {
-            gameState.MovePiece(activePiece, position);
+            gameState.MovePiece(activePiece.transform.position, position);
             activePiece.Deselect();
             activePiece = null;
         }

--- a/3D Chess/Assets/Scripts/PieceEntity.cs
+++ b/3D Chess/Assets/Scripts/PieceEntity.cs
@@ -11,12 +11,12 @@ public class PieceEntity : RealmObject
 
     public Vector3 Position
     {
-        get => positionEntity.ToVector3();
-        set => positionEntity = new Vector3Entity(value);
+        get => PositionEntity.ToVector3();
+        set => PositionEntity = new Vector3Entity(value);
     }
 
     private int Type { get; set; }
-    private Vector3Entity positionEntity { get; set; }
+    private Vector3Entity PositionEntity { get; set; }
 
     public PieceEntity(PieceType type, Vector3 position)
     {
@@ -24,32 +24,16 @@ public class PieceEntity : RealmObject
         Position = position;
     }
 
+    protected override void OnPropertyChanged(string propertyName)
+    {
+        if (propertyName == nameof(PositionEntity))
+        {
+            RaisePropertyChanged(nameof(Position));
+        }
+    }
+
     private PieceEntity()
     {
 
-    }
-}
-
-public class Vector3Entity : EmbeddedObject
-{
-    public float X { get; set; }
-    public float Y { get; set; }
-    public float Z { get; set; }
-
-    private Vector3Entity()
-    {
-
-    }
-
-    public Vector3Entity(Vector3 vector)
-    {
-        X = vector.x;
-        Y = vector.y;
-        Z = vector.z;
-    }
-
-    public Vector3 ToVector3()
-    {
-        return new Vector3(X, Y, Z);
     }
 }

--- a/3D Chess/Assets/Scripts/PieceSpawner.cs
+++ b/3D Chess/Assets/Scripts/PieceSpawner.cs
@@ -1,5 +1,4 @@
 using Realms;
-using System.Linq;
 using UnityEngine;
 
 public class PieceSpawner : MonoBehaviour
@@ -18,77 +17,53 @@ public class PieceSpawner : MonoBehaviour
     [SerializeField] private Piece prefabWhiteQueen = default;
     [SerializeField] private Piece prefabWhiteRook = default;
 
-    public void LoadBoard(GameObject parent)
+    public void CreateNewBoard(Realm realm)
     {
-        var realm = Realm.GetInstance();
-        var pieceEntities = realm.All<PieceEntity>();
+        realm.Write(() =>
+        {
+            realm.RemoveAll<PieceEntity>();
 
-        // Check if we actually have PieceEntity's (which means we resume a game).
-        if (pieceEntities.Count() > 0)
-        {
-            // Each RealmObject needs a corresponding GameObject to represent it.
-            foreach (PieceEntity pieceEntity in pieceEntities)
-            {
-                PieceType type = pieceEntity.PieceType;
-                Vector3 position = pieceEntity.Position;
-                SpawnPiece(type, position, parent);
-            }
-        }
-        else
-        {
-            // No game was saved, create a new board.
-            CreateNewBoard(parent);
-        }
+            realm.Add(new PieceEntity(PieceType.WhiteRook, new Vector3(1, 0, 1)));
+            realm.Add(new PieceEntity(PieceType.WhiteKnight, new Vector3(2, 0, 1)));
+            realm.Add(new PieceEntity(PieceType.WhiteBishop, new Vector3(3, 0, 1)));
+            realm.Add(new PieceEntity(PieceType.WhiteQueen, new Vector3(4, 0, 1)));
+            realm.Add(new PieceEntity(PieceType.WhiteKing, new Vector3(5, 0, 1)));
+            realm.Add(new PieceEntity(PieceType.WhiteBishop, new Vector3(6, 0, 1)));
+            realm.Add(new PieceEntity(PieceType.WhiteKnight, new Vector3(7, 0, 1)));
+            realm.Add(new PieceEntity(PieceType.WhiteRook, new Vector3(8, 0, 1)));
+
+            realm.Add(new PieceEntity(PieceType.WhitePawn, new Vector3(1, 0, 2)));
+            realm.Add(new PieceEntity(PieceType.WhitePawn, new Vector3(2, 0, 2)));
+            realm.Add(new PieceEntity(PieceType.WhitePawn, new Vector3(3, 0, 2)));
+            realm.Add(new PieceEntity(PieceType.WhitePawn, new Vector3(4, 0, 2)));
+            realm.Add(new PieceEntity(PieceType.WhitePawn, new Vector3(5, 0, 2)));
+            realm.Add(new PieceEntity(PieceType.WhitePawn, new Vector3(6, 0, 2)));
+            realm.Add(new PieceEntity(PieceType.WhitePawn, new Vector3(7, 0, 2)));
+            realm.Add(new PieceEntity(PieceType.WhitePawn, new Vector3(8, 0, 2)));
+
+            realm.Add(new PieceEntity(PieceType.BlackPawn, new Vector3(1, 0, 7)));
+            realm.Add(new PieceEntity(PieceType.BlackPawn, new Vector3(2, 0, 7)));
+            realm.Add(new PieceEntity(PieceType.BlackPawn, new Vector3(3, 0, 7)));
+            realm.Add(new PieceEntity(PieceType.BlackPawn, new Vector3(4, 0, 7)));
+            realm.Add(new PieceEntity(PieceType.BlackPawn, new Vector3(5, 0, 7)));
+            realm.Add(new PieceEntity(PieceType.BlackPawn, new Vector3(6, 0, 7)));
+            realm.Add(new PieceEntity(PieceType.BlackPawn, new Vector3(7, 0, 7)));
+            realm.Add(new PieceEntity(PieceType.BlackPawn, new Vector3(8, 0, 7)));
+
+            realm.Add(new PieceEntity(PieceType.BlackRook, new Vector3(1, 0, 8)));
+            realm.Add(new PieceEntity(PieceType.BlackKnight, new Vector3(2, 0, 8)));
+            realm.Add(new PieceEntity(PieceType.BlackBishop, new Vector3(3, 0, 8)));
+            realm.Add(new PieceEntity(PieceType.BlackQueen, new Vector3(4, 0, 8)));
+            realm.Add(new PieceEntity(PieceType.BlackKing, new Vector3(5, 0, 8)));
+            realm.Add(new PieceEntity(PieceType.BlackBishop, new Vector3(6, 0, 8)));
+            realm.Add(new PieceEntity(PieceType.BlackKnight, new Vector3(7, 0, 8)));
+            realm.Add(new PieceEntity(PieceType.BlackRook, new Vector3(8, 0, 8)));
+        });
     }
 
-    public void CreateNewBoard(GameObject parent)
+    public void SpawnPiece(PieceEntity pieceEntity, GameObject parent)
     {
-        // First clear the board, then recreate it from scratch.
-        foreach (var piece in parent.GetComponentsInChildren<Piece>())
-        {
-            piece.RemoveFromBoard();
-        }
-
-        SpawnPiece(PieceType.WhiteRook, new Vector3(1, 0, 1), parent);
-        SpawnPiece(PieceType.WhiteKnight, new Vector3(2, 0, 1), parent);
-        SpawnPiece(PieceType.WhiteBishop, new Vector3(3, 0, 1), parent);
-        SpawnPiece(PieceType.WhiteQueen, new Vector3(4, 0, 1), parent);
-        SpawnPiece(PieceType.WhiteKing, new Vector3(5, 0, 1), parent);
-        SpawnPiece(PieceType.WhiteBishop, new Vector3(6, 0, 1), parent);
-        SpawnPiece(PieceType.WhiteKnight, new Vector3(7, 0, 1), parent);
-        SpawnPiece(PieceType.WhiteRook, new Vector3(8, 0, 1), parent);
-
-        SpawnPiece(PieceType.WhitePawn, new Vector3(1, 0, 2), parent);
-        SpawnPiece(PieceType.WhitePawn, new Vector3(2, 0, 2), parent);
-        SpawnPiece(PieceType.WhitePawn, new Vector3(3, 0, 2), parent);
-        SpawnPiece(PieceType.WhitePawn, new Vector3(4, 0, 2), parent);
-        SpawnPiece(PieceType.WhitePawn, new Vector3(5, 0, 2), parent);
-        SpawnPiece(PieceType.WhitePawn, new Vector3(6, 0, 2), parent);
-        SpawnPiece(PieceType.WhitePawn, new Vector3(7, 0, 2), parent);
-        SpawnPiece(PieceType.WhitePawn, new Vector3(8, 0, 2), parent);
-
-        SpawnPiece(PieceType.BlackPawn, new Vector3(1, 0, 7), parent);
-        SpawnPiece(PieceType.BlackPawn, new Vector3(2, 0, 7), parent);
-        SpawnPiece(PieceType.BlackPawn, new Vector3(3, 0, 7), parent);
-        SpawnPiece(PieceType.BlackPawn, new Vector3(4, 0, 7), parent);
-        SpawnPiece(PieceType.BlackPawn, new Vector3(5, 0, 7), parent);
-        SpawnPiece(PieceType.BlackPawn, new Vector3(6, 0, 7), parent);
-        SpawnPiece(PieceType.BlackPawn, new Vector3(7, 0, 7), parent);
-        SpawnPiece(PieceType.BlackPawn, new Vector3(8, 0, 7), parent);
-
-        SpawnPiece(PieceType.BlackRook, new Vector3(1, 0, 8), parent);
-        SpawnPiece(PieceType.BlackKnight, new Vector3(2, 0, 8), parent);
-        SpawnPiece(PieceType.BlackBishop, new Vector3(3, 0, 8), parent);
-        SpawnPiece(PieceType.BlackQueen, new Vector3(4, 0, 8), parent);
-        SpawnPiece(PieceType.BlackKing, new Vector3(5, 0, 8), parent);
-        SpawnPiece(PieceType.BlackBishop, new Vector3(6, 0, 8), parent);
-        SpawnPiece(PieceType.BlackKnight, new Vector3(7, 0, 8), parent);
-        SpawnPiece(PieceType.BlackRook, new Vector3(8, 0, 8), parent);
-    }
-
-    private void SpawnPiece(PieceType pieceType, Vector3 position, GameObject parent)
-    {
-        var piecePrefab = pieceType switch
+        var piecePrefab = pieceEntity.PieceType switch
         {
             PieceType.BlackBishop => prefabBlackBishop,
             PieceType.BlackKing => prefabBlackKing,
@@ -105,6 +80,7 @@ public class PieceSpawner : MonoBehaviour
             _ => throw new System.Exception("Invalid piece type.")
         };
 
-        Instantiate(piecePrefab, position, Quaternion.identity, parent.transform);
+        var piece = Instantiate(piecePrefab, pieceEntity.Position, Quaternion.identity, parent.transform);
+        piece.Entity = pieceEntity;
     }
 }

--- a/3D Chess/Assets/Scripts/Vector3Entity.cs
+++ b/3D Chess/Assets/Scripts/Vector3Entity.cs
@@ -1,0 +1,26 @@
+﻿using Realms;
+using UnityEngine;
+
+public class Vector3Entity : EmbeddedObject
+{
+    public float X { get; private set; }
+    public float Y { get; private set; }
+    public float Z { get; private set; }
+
+    private Vector3Entity()
+    {
+
+    }
+
+    public Vector3Entity(Vector3 vector)
+    {
+        X = vector.x;
+        Y = vector.y;
+        Z = vector.z;
+    }
+
+    public Vector3 ToVector3()
+    {
+        return new Vector3(X, Y, Z);
+    }
+}

--- a/3D Chess/Assets/Scripts/Vector3Entity.cs.meta
+++ b/3D Chess/Assets/Scripts/Vector3Entity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 051a82915c1cd6b489a3f3cff046f2bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR represents an alternative implementation for the [local realm PR](https://github.com/realm/unity-examples-3d-chess/pull/2).

It evolves mainly around the `private PieceEntity pieceEntity;` in `Piece`.

In the other PR the changes in Realm were driven by the changes of GameObjects (movement, attacking, etc.).
This PR basically does it exactly the other way round by driving changes from the Realm point of view and using notifications, watching for changes.

While reviewing the changes themselves the main question while doing this should be:
- Which way do you prefer?
- Which one is easier to understand for a new user?
